### PR TITLE
MDP state dependent + state attribute based movements

### DIFF
--- a/src/DiagonalGridWorld.jl
+++ b/src/DiagonalGridWorld.jl
@@ -1,27 +1,15 @@
-@with_kw struct DiagonalGridWorld <: GridWorld
-    size::Tuple{Int, Int}           = (10,10)
-    rewards::Dict{Vec2, Float64}    = Dict(Vec2(4,3)=>-10.0, Vec2(4,6)=>-5.0, Vec2(9,3)=>10.0, Vec2(8,8)=>3.0)
-    terminate_in::Set{Vec2}         = Set((Vec2(4,3), Vec2(4,6), Vec2(9,3), Vec2(8,8)))
-    tprob::Float64                  = 0.7
-    discount::Float64               = 0.95
-end
 
-function POMDPs.states(mdp::GridWorld)
-    vec(StateTypes[Vec2(x, y) for x in 1:mdp.size[1], y in mdp.size[2]])
-end
-
-POMDPs.actions(mdp::DiagonalGridWorld) = SVector(:n, :nw, :w, :sw, :s, :se, :e, :ne)
-POMDPs.n_states(mdp::DiagonalGridWorld) = prod(mdp.size)
-POMDPs.n_actions(mdp::DiagonalGridWorld) = 8
-POMDPs.discount(mdp::DiagonalGridWorld) = mdp.discount
+POMDPs.actions(mdp::GridWorld{DiagonalGWState}) = SVector(:n, :nw, :w, :sw, :s, :se, :e, :ne)
+POMDPs.n_states(mdp::GridWorld{DiagonalGWState}) = prod(mdp.size)
+POMDPs.n_actions(mdp::GridWorld{DiagonalGWState}) = 8
 
 """ returns the index corresponding to a 'symbolic' action """
-function POMDPs.actionindex(mdp::DiagonalGridWorld, a::Symbol)
+function POMDPs.actionindex(mdp::GridWorld{DiagonalGWState}, a::Symbol)
     aind = Dict(:n=>1, :nw=>2, :w=>3, :sw=>4, :s=>5, :se=>6, :e=>7, :ne=>8)
     aind[a]
 end
 
 """ Returns dictionary connecting action to the 2D vector movement it represents """
-function directions(mdp::DiagonalGridWorld)
+function directions(mdp::GridWorld{DiagonalGWState})
     Dict(:n=>Vec2(0,1), :nw=>Vec2(-1,1), :w=>Vec2(-1,0), :sw=>Vec2(-1,-1), :s=>Vec2(0,-1), :se=>Vec2(1,-1), :e=>Vec2(1,0), :ne=>Vec2(1,1))
 end

--- a/src/General.jl
+++ b/src/General.jl
@@ -2,13 +2,29 @@
 ### Defines generic functions for GridWorlds ###
 ################################################
 
+@with_kw struct GridWorld{T<:AbstractGWState} <: AbstractGridWorld
+    size::Tuple{Int, Int}               = (10,10)
+    rewards::Dict{Vec2, Float64}        = Dict(Vec2(4,3)=>-10.0, Vec2(4,6)=>-5.0, Vec2(9,3)=>10.0, Vec2(8,8)=>3.0)
+    terminate_in::Set{Vec2}             = Set((Vec2(4,3), Vec2(4,6), Vec2(9,3), Vec2(8,8)))
+    tprob::Float64                      = 0.7
+    discount::Float64                   = 0.95
+    states::Union{AbstractMatrix,Dict}  = Dict()
+end
+""" Make default grid world "simple" """
+GridWorld(args...) = GridWorld{SimpleGWState}(args...)
+
+function POMDPs.states(mdp::GridWorld)
+    vec([Vec2(x, y) for x in 1:mdp.size[1], y in mdp.size[2]])
+end
+
+
 POMDPs.discount(mdp::GridWorld) = mdp.discount
 POMDPs.stateindex(mdp::GridWorld, s::Vec2) = LinearIndices(mdp.size)[s...]
 POMDPs.reward(mdp::GridWorld, s::Vec2, a::Symbol) = get(mdp.rewards, s, 0.0)
 
 
 POMDPs.initialstate_distribution(mdp::GridWorld) = uniform_belief(mdp)
-POMDPs.initialstate(mdp::GridWorld, rng::AbstractRNG) = Vec2(rand(rng, 1:mdp.size[1]), rand(rng, 1:mdp.size[2]))
+POMDPs.initialstate(mdp::GridWorld, rng::AbstractRNG) = StateType(rand(rng, 1:mdp.size[1]), rand(rng, 1:mdp.size[2]))
 POMDPs.isterminal(mdp::GridWorld, s::Vec2) = s ∈ mdp.terminate_in
 inbounds(mdp::GridWorld, nb::Vec2) = ( 0 < nb[1] < mdp.size[1] ) && ( 0 < nb[2] < mdp.size[2] )
 
@@ -17,15 +33,20 @@ POMDPs.convert_a(::Type{Symbol}, a::AbstractArray, mdp::GridWorld) = actions(mdp
 
 # If directions(mdp,s) is not overloaded, it will automatically dispatch to
 # its non-state dependent version
-directions(mdp::GridWorld, s::Vec2) = directions(mdp::GridWorld)
+directions(mdp::GridWorld, t::Type{<:AbstractGWState}) = directions(mdp::GridWorld)
+
+""" Returns the state type of a coordinate """
+function state_type(mdp::GridWorld{T}, s::Vec2) where T<:AbstractGWState
+    s_type = get(mdp.states, s, T)
+end
 
 """
     Returns a Categorical sparse probability distribution over the set of possible
     future states given current state s, and action a.
 """
 function POMDPs.transition(mdp::GridWorld, s::Vec2, a::Symbol)
-    dir = directions(mdp, s)
-    if s in mdp.terminate_in
+    dir = directions(mdp, state_type(mdp, s) )
+    if s ∈ mdp.terminate_in
         return SparseCat([s], [1.0])
     end
 

--- a/src/GridWorlds.jl
+++ b/src/GridWorlds.jl
@@ -13,8 +13,13 @@ import POMDPs: initialstate, initialstate_distribution
 import POMDPs: reward
 import POMDPs: convert_a
 
+
 const Vec2 = SVector{2,Int}
-const StateTypes = Vec2
+const StateType = Vec2
+
+abstract type AbstractGWState end
+abstract type SimpleGWState <: AbstractGWState end
+abstract type DiagonalGWState <: AbstractGWState end
 
 # TODO: action/state-action reward
 # abstract type Reward end
@@ -22,7 +27,7 @@ const StateTypes = Vec2
 # abstract type StateActionReward <: Reward end
 # TODO: parametrised StateTypes?
 
-abstract type GridWorld <: MDP{StateTypes, Symbol} end
+abstract type AbstractGridWorld <: MDP{AbstractGWState, Union{Symbol,Integer} } end
 
 include("General.jl")
 include("SimpleGridWorld.jl")
@@ -30,10 +35,11 @@ include("DiagonalGridWorld.jl")
 
 export
     Vec2,
-    GridWorld,
-    SimpleGridWorld,
-    DiagonalGridWorld
-
+	AbstractGWState,
+	SimpleGWState,
+	DiagonalGWState,
+	AbstractGridWorld,
+	GridWorld
 
 export
     actions,
@@ -44,6 +50,8 @@ export
     stateindex,
     transition,
     reward,
-    isterminal
+    isterminal,
+	state_type,
+	directions
 
 end

--- a/src/SimpleGridWorld.jl
+++ b/src/SimpleGridWorld.jl
@@ -1,31 +1,15 @@
-@with_kw struct SimpleGridWorld <: GridWorld
-    size::Tuple{Int, Int}           = (10,10)
-    rewards::Dict{Vec2, Float64}    = Dict(Vec2(4,3)=>-10.0, Vec2(4,6)=>-5.0, Vec2(9,3)=>10.0, Vec2(8,8)=>3.0)
-    terminate_in::Set{Vec2}         = Set((Vec2(4,3), Vec2(4,6), Vec2(9,3), Vec2(8,8)))
-    tprob::Float64                  = 0.7
-    discount::Float64               = 0.95
-end
 
-function POMDPs.states(mdp::GridWorld)
-    vec(StateTypes[Vec2(x, y) for x in 1:mdp.size[1], y in mdp.size[2]])
-end
+POMDPs.actions(mdp::GridWorld{SimpleGWState}) = SVector(:up, :down, :left, :right)
+POMDPs.n_states(mdp::GridWorld{SimpleGWState}) = prod(mdp.size)
+POMDPs.n_actions(mdp::GridWorld{SimpleGWState}) = 4
 
-POMDPs.actions(mdp::SimpleGridWorld) = SVector(:up, :down, :left, :right)
-POMDPs.n_states(mdp::SimpleGridWorld) = prod(mdp.size)
-POMDPs.n_actions(mdp::SimpleGridWorld) = 4
-
-function POMDPs.actionindex(mdp::SimpleGridWorld, a::Symbol)
+""" returns the index corresponding to a 'symbolic' action """
+function POMDPs.actionindex(mdp::GridWorld{SimpleGWState}, a::Symbol)
     aind = Dict(:up=>1, :down=>2, :left=>3, :right=>4)
     aind[a]
 end
 
-function directions(mdp::SimpleGridWorld)
+""" Returns dictionary connecting action to the 2D vector movement it represents """
+function directions(mdp::GridWorld{SimpleGWState})
     Dict(:up=>Vec2(0,1), :down=>Vec2(0,-1), :left=>Vec2(-1,0), :right=>Vec2(1,0))
 end
-
-
-inbounds(mdp::GridWorld, nb::Vec2) = ( 0 < nb[1] < mdp.size[1] ) && ( 0 < nb[2] < mdp.size[2] )
-
-
-POMDPs.convert_a(::Type{A}, a::Symbol, mdp::SimpleGridWorld) where A<:AbstractArray = convert(A, SVector(actionindex(mdp)[a]))
-POMDPs.convert_a(::Type{Symbol}, a::AbstractArray, mdp::SimpleGridWorld) = actions(mdp)[first(a)]

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -3,7 +3,9 @@ using GridWorlds
 using POMDPModelTools
 
 let
-	problem = DiagonalGridWorld()
+	problem = GridWorld{DiagonalGWState}()
+
+	@test typeof(problem) == GridWorld{DiagonalGWState}
 
 	@test n_states(problem) == 100
 	@test n_actions(problem) == 8

--- a/test/simple.jl
+++ b/test/simple.jl
@@ -3,7 +3,9 @@ using GridWorlds
 using POMDPModelTools
 
 let
-    problem = SimpleGridWorld()
+    problem = GridWorld()
+
+	@test typeof(problem) == GridWorld{SimpleGWState}
 
 	@test n_states(problem) == 100
 	@test n_actions(problem) == 4


### PR DESCRIPTION
Made MDP have a default state, such as simple state with the up/down/left/right transitions.
Each particular cell can then have its own state type, with its own transitions, allowing more varied and easy customisation.